### PR TITLE
Add the option to skip YAMLs that don't contain "apiVersion", "kind" and "metadata.name"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Flags:
   -h, --help                help for kubectl-split
   -f, --input-file string   the input file used to read the initial macro YAML file. If empty or "-", stdin is used
   -o, --output-dir string   the output directory used to output the splitted files (default ".")
+  -s, --skip-non-k8s        if enabled, any YAMLs that don't contain at least an "apiVersion", "kind" and "metadata.name" will be excluded from the split
   -t, --template string     go template used to generate the file name when creating the resource files in the output directory (default "{{.kind | lower}}-{{.metadata.name}}.yaml")
   -v, --version             version for kubectl-split
 ```
@@ -75,6 +76,10 @@ Flags:
     * If multiple files from your YAML generate the same file name, all YAMLs that match this file name will be appended.
     * If the rendered file name includes a path separator, subfolders under `--output-dir` will be created.
     * If a file already exists in `--output-directory` under this generated file name, their contents will be replaced.
+* `--skip-non-k8s`:
+  * If enabled, any YAMLs that don't contain at least an `apiVersion`, `kind` and `metadata.name` will be excluded from the split
+  * There are no attempts to validate how correct these fields are. For example, there's no check to validate that `apiVersion` exists in a Kubernetes cluster, or whether this `apiVersion` is valid: `"example\foo"`.
+    * It's useful, however, if alongside the original YAML you suspect there might be some non Kubernetes YAMLs being generated.
 
 ## Why `kubectl-split`?
 

--- a/app.go
+++ b/app.go
@@ -49,6 +49,8 @@ func root() *cobra.Command {
 	rootCommand.Flags().StringVarP(&opts.GoTemplate, "template", "t", "{{.kind | lower}}-{{.metadata.name}}.yaml", "go template used to generate the file name when creating the resource files in the output directory")
 	rootCommand.Flags().BoolVar(&opts.DryRun, "dry-run", false, "if true, no files are created, but the potentially generated files will be printed as the command output")
 	rootCommand.Flags().BoolVar(&opts.DebugMode, "debug", false, "enable debug mode")
+	rootCommand.Flags().BoolVarP(&opts.StrictKubernetes, "skip-non-k8s", "s", false, "if enabled, any YAMLs that don't contain at least an \"apiVersion\", \"kind\" and \"metadata.name\" will be excluded from the split")
+
 	rootCommand.Flags().MarkHidden("debug")
 
 	return rootCommand

--- a/split/errors.go
+++ b/split/errors.go
@@ -1,0 +1,15 @@
+package split
+
+import "fmt"
+
+type strictModeErr struct {
+	fileNumber int
+	fieldName  string
+}
+
+func (s *strictModeErr) Error() string {
+	return fmt.Sprintf(
+		"YAML file number %d does not contain a Kubernetes %q field or the field is invalid or empty",
+		s.fileNumber, s.fieldName,
+	)
+}

--- a/split/execute.go
+++ b/split/execute.go
@@ -37,6 +37,13 @@ func (s *Split) processSingleYAML(contents []byte, position int, template *templ
 		return "", fmt.Errorf("unable to render file name for YAML file number %d: %w", position, improveExecError(err))
 	}
 
+	// Check if file contains at least some Kubernetes keys
+	if s.opts.StrictKubernetes {
+		if err := checkKubernetesBasics(manifest, position); err != nil {
+			return "", err
+		}
+	}
+
 	// Trim the file name
 	name := strings.TrimSpace(buf.String())
 
@@ -48,6 +55,40 @@ func (s *Split) processSingleYAML(contents []byte, position int, template *templ
 	}
 
 	return name, nil
+}
+
+func checkStringInMap(local map[string]interface{}, key, keyprefix string, fileNumber int) error {
+	iface, found := local[key]
+
+	if !found {
+		return &strictModeErr{fileNumber, keyprefix + key}
+	}
+
+	if _, ok := iface.(string); !ok {
+		return &strictModeErr{fileNumber, keyprefix + key}
+	}
+
+	return nil
+}
+
+func checkKubernetesBasics(manifest map[string]interface{}, fileNumber int) error {
+	if err := checkStringInMap(manifest, "apiVersion", "", fileNumber); err != nil {
+		return err
+	}
+
+	if err := checkStringInMap(manifest, "kind", "", fileNumber); err != nil {
+		return err
+	}
+
+	if metadata, found := manifest["metadata"]; !found {
+		return &strictModeErr{fileNumber, "metadata"}
+	} else {
+		if err := checkStringInMap(metadata.(map[string]interface{}), "name", "metadata.", fileNumber); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Execute runs the process according to the split.Options provided. This will
@@ -98,6 +139,12 @@ func (s *Split) Execute() error {
 		// Send it for processing
 		name, err := s.processSingleYAML(currentFile, fileCount, s.template)
 		if err != nil {
+			if _, ok := err.(*strictModeErr); ok {
+				s.log.Printf("Skipping file: %s", err.Error())
+				fileCount++
+				return nil
+			}
+
 			return err
 		}
 

--- a/split/split.go
+++ b/split/split.go
@@ -43,4 +43,6 @@ type Options struct {
 	GoTemplate      string // the go template code to render the file names
 	DryRun          bool   // if true, no files are created
 	DebugMode       bool
+
+	StrictKubernetes bool // if true, any YAMLs that don't contain at least an "apiVersion", "kind" and "metadata.name" will be excluded
 }


### PR DESCRIPTION
This partially fixes #3: it allows the caller to skip any resource that doesn't have an `apiVersion`, `kind` and `metadata.name`. For a file to be included, these 3 fields need to exist and must not be empty although, besides that, there are no other checks performed.