### PR TITLE
Add sorting support and printing to stdout instead of files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ Flags:
   -h, --help                   help for kubectl-slice
   -i, --include-kind strings   kinds to include in the output (singular, case insensitive); if empty, all Kubernetes object kinds are included
   -f, --input-file string      the input file used to read the initial macro YAML file; if empty or "-", stdin is used
-  -o, --output-dir string      the output directory used to output the splitted files (default ".")
+  -o, --output-dir string      the output directory used to output the splitted files
   -s, --skip-non-k8s           if enabled, any YAMLs that don't contain at least an "apiVersion", "kind" and "metadata.name" will be excluded from the split
+      --sort-by-kind           if enabled, resources are sorted by Kind, a la Helm, before saving them to disk
+      --stdout                 if enabled, no resource is written to disk and all resources are printed to stdout instead
   -t, --template string        go template used to generate the file name when creating the resource files in the output directory (default "{{.kind | lower}}-{{.metadata.name}}.yaml")
   -v, --version                version for kubectl-slice
 ```
@@ -120,6 +122,11 @@ Flags:
   * If enabled, any YAMLs that don't contain at least an `apiVersion`, `kind` and `metadata.name` will be excluded from the split
   * There are no attempts to validate how correct these fields are. For example, there's no check to validate that `apiVersion` exists in a Kubernetes cluster, or whether this `apiVersion` is valid: `"example\foo"`.
     * It's useful, however, if alongside the original YAML you suspect there might be some non Kubernetes YAMLs being generated.
+* `--sort-by-kind`:
+  * If enabled, resources are sorted by Kind, like Helm does, before saving them to disk or printing them to `stdout`.
+  * If this flag is not present, resources are outputted following the order in which they were found in the YAML file.
+* `--stdout`:
+  * If enabled, no resource is written to disk and all resources are printed to `stdout` instead, useful if you want to pipe the output of `kubectl-slice` to another command or to itself. File names are still generated, but used as reference and prepended at the top of each file in the multi-YAML output. Other than that, the file name template has no effect -- it won't create any subfolders, for example.
 
 ## Why `kubectl-slice`?
 

--- a/app.go
+++ b/app.go
@@ -46,13 +46,15 @@ func root() *cobra.Command {
 	}
 
 	rootCommand.Flags().StringVarP(&opts.InputFile, "input-file", "f", "", "the input file used to read the initial macro YAML file; if empty or \"-\", stdin is used")
-	rootCommand.Flags().StringVarP(&opts.OutputDirectory, "output-dir", "o", ".", "the output directory used to output the splitted files")
+	rootCommand.Flags().StringVarP(&opts.OutputDirectory, "output-dir", "o", "", "the output directory used to output the splitted files")
 	rootCommand.Flags().StringVarP(&opts.GoTemplate, "template", "t", slice.DefaultTemplateName, "go template used to generate the file name when creating the resource files in the output directory")
 	rootCommand.Flags().BoolVar(&opts.DryRun, "dry-run", false, "if true, no files are created, but the potentially generated files will be printed as the command output")
 	rootCommand.Flags().BoolVar(&opts.DebugMode, "debug", false, "enable debug mode")
 	rootCommand.Flags().StringSliceVarP(&opts.IncludedKinds, "include-kind", "i", nil, "kinds to include in the output (singular, case insensitive); if empty, all Kubernetes object kinds are included")
 	rootCommand.Flags().StringSliceVarP(&opts.ExcludedKinds, "exclude-kind", "e", nil, "kinds to exclude in the output (singular, case insensitive); if empty, all Kubernetes object kinds are excluded")
 	rootCommand.Flags().BoolVarP(&opts.StrictKubernetes, "skip-non-k8s", "s", false, "if enabled, any YAMLs that don't contain at least an \"apiVersion\", \"kind\" and \"metadata.name\" will be excluded from the split")
+	rootCommand.Flags().BoolVar(&opts.SortByKind, "sort-by-kind", false, "if enabled, resources are sorted by Kind, a la Helm, before saving them to disk")
+	rootCommand.Flags().BoolVar(&opts.OutputToStdout, "stdout", false, "if enabled, no resource is written to disk and all resources are printed to stdout instead")
 
 	rootCommand.Flags().MarkHidden("debug")
 

--- a/slice/kube.go
+++ b/slice/kube.go
@@ -1,0 +1,83 @@
+package slice
+
+import "sort"
+
+type yamlFile struct {
+	name string
+	kind string
+	data []byte
+}
+
+// from: https://github.com/helm/helm/blob/v3.7.1/pkg/releaseutil/kind_sorter.go#L31
+var helmInstallOrder = []string{
+	"Namespace",
+	"NetworkPolicy",
+	"ResourceQuota",
+	"LimitRange",
+	"PodSecurityPolicy",
+	"PodDisruptionBudget",
+	"ServiceAccount",
+	"Secret",
+	"SecretList",
+	"ConfigMap",
+	"StorageClass",
+	"PersistentVolume",
+	"PersistentVolumeClaim",
+	"CustomResourceDefinition",
+	"ClusterRole",
+	"ClusterRoleList",
+	"ClusterRoleBinding",
+	"ClusterRoleBindingList",
+	"Role",
+	"RoleList",
+	"RoleBinding",
+	"RoleBindingList",
+	"Service",
+	"DaemonSet",
+	"Pod",
+	"ReplicationController",
+	"ReplicaSet",
+	"Deployment",
+	"HorizontalPodAutoscaler",
+	"StatefulSet",
+	"Job",
+	"CronJob",
+	"Ingress",
+	"APIService",
+}
+
+func sortYAMLsByKind(manifests []yamlFile) []yamlFile {
+	sort.SliceStable(manifests, func(i, j int) bool {
+		return lessByKind(manifests[i], manifests[j], manifests[i].kind, manifests[j].kind, helmInstallOrder)
+	})
+
+	return manifests
+}
+
+// from: https://github.com/helm/helm/blob/v3.7.1/pkg/releaseutil/kind_sorter.go#L131
+func lessByKind(a interface{}, b interface{}, kindA string, kindB string, o []string) bool {
+	ordering := make(map[string]int, len(o))
+	for v, k := range o {
+		ordering[k] = v
+	}
+
+	first, aok := ordering[kindA]
+	second, bok := ordering[kindB]
+
+	if !aok && !bok {
+		// if both are unknown then sort alphabetically by kind, keep original order if same kind
+		if kindA != kindB {
+			return kindA < kindB
+		}
+		return first < second
+	}
+	// unknown kind is last
+	if !aok {
+		return false
+	}
+	if !bok {
+		return true
+	}
+	// sort different kinds, keep original order if same priority
+	return first < second
+}

--- a/slice/plural.go
+++ b/slice/plural.go
@@ -1,0 +1,8 @@
+package slice
+
+func pluralize(s string, n int) string {
+	if n == 1 {
+		return s
+	}
+	return s + "s"
+}

--- a/slice/split.go
+++ b/slice/split.go
@@ -19,7 +19,7 @@ type Split struct {
 	template *template.Template
 	data     *bytes.Buffer
 
-	filesFound map[string]bytes.Buffer
+	filesFound []yamlFile
 	fileCount  int
 }
 
@@ -45,6 +45,7 @@ func New(opts Options) (*Split, error) {
 type Options struct {
 	InputFile       string // the name of the input file to be read
 	OutputDirectory string // the path to the directory where the files will be stored
+	OutputToStdout  bool   // if true, the output will be written to stdout instead of a file
 	GoTemplate      string // the go template code to render the file names
 	DryRun          bool   // if true, no files are created
 	DebugMode       bool   // enables debug mode
@@ -52,4 +53,6 @@ type Options struct {
 	IncludedKinds    []string
 	ExcludedKinds    []string
 	StrictKubernetes bool // if true, any YAMLs that don't contain at least an "apiVersion", "kind" and "metadata.name" will be excluded
+
+	SortByKind bool // if true, it will sort the resources by kind
 }

--- a/slice/validate.go
+++ b/slice/validate.go
@@ -17,8 +17,14 @@ func (s *Split) init() error {
 
 	s.data = buf
 
-	if s.opts.OutputDirectory == "" {
-		return fmt.Errorf("output directory is empty")
+	if s.opts.OutputToStdout {
+		if s.opts.OutputDirectory != "" {
+			return fmt.Errorf("cannot specify both output to stdout and output to file: output directory is present")
+		}
+	} else {
+		if s.opts.OutputDirectory == "" {
+			return fmt.Errorf("output directory is empty")
+		}
 	}
 
 	if err := s.compileTemplate(); err != nil {


### PR DESCRIPTION
* Changes any non-code output to be printed to `stderr`. If a file is ever printed, it will be printed to `stdout`.
* Allows sorting by kind, the same way Helm does. It's still to be decided if sorting alphabetically by resource name makes sense or not -- especially considering it might be better to sort alphabetically by generated template name instead!