### PR TITLE
Related to issue #83: Added support for container image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Create and publish Docker image
+
+on:
+  push:
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      # 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.history

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+## Go builder image
+FROM golang:1.20.3 as builder
+
+ENV GOPATH=/usr/local/go/bin
+
+WORKDIR /go
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build -ldflags "-s" -a -installsuffix cgo .
+
+## Base image for production usage
+FROM alpine:3.14 as production
+
+COPY --from=builder /go/kubectl-slice /usr/bin/kubectl-slice
+
+WORKDIR /workdir
+
+## add user k8s to run the slice tool
+RUN set -eux; \
+  addgroup -g 1000 k8s; \
+  adduser -u 1000 -G k8s -s /bin/sh -h /home/k8s -D k8s
+
+RUN chown -R k8s:k8s /workdir
+
+USER k8s
+
+ENTRYPOINT ["/usr/bin/kubectl-slice"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,42 @@
+# Running in docker  
+  
+Run docker image from gchr.io/patrickdappollonio/kubectl-slice
+
+## Usage
+The container is build to execute the the kubectl-slice tool inline. 
+   
+Example:  
+`docker run --rm -v "${PWD}/slice/testdata":workdir kubectl-slice -f ingress-namespace.yaml -o ./`  
+  
+This will split the ingress-namespace.yaml file in the directory ${PWD}/slice/testdata.  
+  
+For help use:  
+`docker run --rm -v "${PWD}/slice/testdata":workdir kubectl-slice -h`
+
+Statements to kubectl-slice can be wrapped in `""` if the commandline escapes unintentionally.  
+Example:  
+`docker run --rm -v "${PWD}/slice/testdata":workdir kubectl-slice "-h"`
+  
+## Manual build the docker image  
+Requires docker or another OCI tool.  
+
+Follow these steps:  
+1. Clone the repo and cd into the project
+1. Run `docker build . -t kubectl-slice`
+
+## Manual push the docker image  
+A 3rd. party container registry like docker hub is needed to do this.  
+
+1. Run `docker tag kubectl-slice:latest YOUR_REGISTRY.com/ORG/kubectl-slice:1.0`
+1. Run `docker push YOUR_REGISTRY.com/ORG/kubectl-slice:1.0`
+
+## Running arm locally but x86/x64 on the endpoint
+
+Requires buildkit from (moby)[https://github.com/moby/buildkit] installed.  
+
+Example change the dockerfile:  
+`FROM --platform=linux/amd64 golang:1.20.3 as builder`  
+`FROM --platform=linux/amd64 alpine:3.14 as production`  
+  
+Example run direct inline build command instead:  
+`Docker buildx build --platform linux/amd64 . -t kubectl-slice`


### PR DESCRIPTION
Added:
dockerfile
docker.md documentation on usage and build-it-yourself
workflow for building and pushing container image to gchr.io

Might need edits in .github/workflow/docker.yml to work, if the ${{ secrets.GITHUB_TOKEN }} needs permissions.